### PR TITLE
Bump PyYAML version for security fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ Pillow==11.1.0
 pyparsing==2.4.7
 python-dateutil==2.8.1
 pytz==2020.1
-PyYAML==5.3.1
+PyYAML==5.4
 regex==2020.10.28
 requests==2.32.3
 sacremoses==0.0.43


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix security vulnerability by updating PyYAML to 5.4.